### PR TITLE
fix: Handle failed purl2cpe download at first run

### DIFF
--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -441,14 +441,21 @@ class CVEDB:
     def populate_purl2cpe(self):
         """Transfers data from PURL2CPE database to CVE database."""
 
-        purl2cpe_conn = sqlite3.connect(self.cachedir / "purl2cpe/purl2cpe.db")
+        purl2cpe_dbpath = self.cachedir / "purl2cpe/purl2cpe.db"
+
+        # check if downloaded DB exists; if not, we should avoid operating on an empty DB
+        if not purl2cpe_dbpath.is_file():
+            self.LOGGER.error("PURL2CPE downloaded data not found, skipping!")
+            return
+
+        purl2cpe_conn = sqlite3.connect(purl2cpe_dbpath)
         purl2cpe_cursor = purl2cpe_conn.cursor()
 
         cve_conn = sqlite3.connect(self.dbpath)
         cve_cursor = cve_conn.cursor()
 
         # we are occasionally seeing an error where the cache doesn't have
-        # purl2cpe and thus we get an error, so attempt to initalize here
+        # purl2cpe and thus we get an error, so attempt to initialize here
         cve_cursor.execute(self.TABLE_SCHEMAS["purl2cpe"])
         cve_cursor.execute(self.INDEXES["purl"])
 


### PR DESCRIPTION
fixes #4889

Gracefully skip the purl2cpe DB populate operation if the database failed to download for some reason. Avoids crash from trying to operate on an empty DB file.